### PR TITLE
fix: string conversion for object

### DIFF
--- a/src/conventional_commits.ts
+++ b/src/conventional_commits.ts
@@ -37,9 +37,15 @@ export const TypeToImpactMapping = {
 
 export type ConventionalCommitType = keyof typeof TypeToImpactMapping;
 
-export interface ParsedCommitInfo {
-  type: ConventionalCommitType;
-  impact: Impact;
+export class ParsedCommitInfo {
+  constructor(
+    public type: ConventionalCommitType,
+    public impact: Impact,
+  ) {}
+
+  toString(): string {
+    return `${this.type} (${Impact[this.impact]})`;
+  }
 }
 
 export function getConventionalImpact(
@@ -116,5 +122,5 @@ export function ParseConventionalTitle(
     core.debug("Detected breaking change indicator '!' in title");
     impact = Impact.MAJOR;
   }
-  return { type, impact };
+  return new ParsedCommitInfo(type, impact);
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,14 +24,14 @@ export async function getImpactFromGithub(
   commits: Commit[],
 ): Promise<ImpactResult> {
   const pr_impact = getConventionalImpact(pr);
-  core.info(`Determined impact from Pull request: ${String(pr_impact)}`);
+  core.info(`Determined impact from Pull request: ${pr_impact ?? 'none'}`);
 
   const commit_impacts: ParsedCommitInfo[] = [];
   // Parse each commit title
   for (const commit of commits) {
     const commit_impact = getConventionalImpact(commit);
     core.debug(`Commit ${commit.sha} title: ${commit.title}`);
-    core.debug(`Determined impact from commit: ${String(commit_impact)}`);
+    core.debug(`Determined impact from commit: ${commit_impact ?? 'none'}`);
     if (commit_impact !== undefined) {
       commit_impacts.push(commit_impact);
     }


### PR DESCRIPTION
Currently the impact for the PR is reported as an `[object Object]`. More specifically: `Determined impact from Pull request: [object Object]`

We need a proper string conversion utility function like e.g. Python's `__str__`. This PR proposes promoting the interface to a class.