### PR TITLE
ci: fix concurrency group for qualify workflow

### DIFF
--- a/.github/workflows/qualify.yaml
+++ b/.github/workflows/qualify.yaml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 concurrency:
-  group: 'qualify-${{ github.event.pull_request.head.sha }}'
+  group: 'qualify-${{ github.ref }}'
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
use github.ref to distinguish between PR events and push events