### PR TITLE
fix: retries for GitHub PR from commit API

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -29,6 +29,47 @@ export function getPrFromContext(): PullRequest | undefined {
   return extractPullRequestFromPayload(ctx.payload as unknown);
 }
 
+/**
+ * Attempt a single lookup of the pull request associated with a commit SHA.
+ * Returns undefined when the association index returns no results or on error.
+ */
+async function fetchPrForCommit(
+  token: string,
+  commitSha: string,
+): Promise<PullRequest | undefined> {
+  try {
+    const { octokit, owner, repo } = getOctokitAndRepo(token);
+    const response =
+      await octokit.rest.repos.listPullRequestsAssociatedWithCommit({
+        owner,
+        repo,
+        commit_sha: commitSha,
+      });
+    if (!Array.isArray(response.data) || response.data.length === 0)
+      return undefined;
+
+    const sourcePr = response.data[0] as PullRequestFromCommit;
+    const prResponse = await octokit.rest.pulls.get({
+      owner,
+      repo,
+      pull_number: sourcePr.number,
+    });
+    const pr = prResponse.data as PullRequest;
+    core.info(`Resolved PR #${pr.number} from latest commit ${commitSha}`);
+    return pr;
+  } catch (err) {
+    core.debug(
+      `fetchPrForCommit failed for commit ${commitSha}: ${String(err)}`,
+    );
+    return undefined;
+  }
+}
+
+/**
+ * Resolve the pull request associated with the latest commit in the Actions
+ * context. Retries with exponential backoff to handle GitHub's eventual
+ * consistency after a squash merge.
+ */
 async function getPrFromLatestCommit(
   token: string,
 ): Promise<PullRequest | undefined> {
@@ -40,35 +81,24 @@ async function getPrFromLatestCommit(
     return undefined;
   }
 
-  try {
-    const { octokit, owner, repo } = getOctokitAndRepo(token);
-    const response =
-      await octokit.rest.repos.listPullRequestsAssociatedWithCommit({
-        owner,
-        repo,
-        commit_sha: commitSha,
-      });
-    if (!Array.isArray(response.data) || response.data.length === 0) {
-      core.debug(`No PRs associated with commit ${commitSha}`);
-      return undefined;
-    }
+  // GitHub's association index can lag after e.g. a squash merge — retry with
+  // exponential backoff to handle eventual consistency.
+  const retryDelaysMs = [5_000, 10_000, 20_000];
 
-    const sourcePr = response.data[0] as PullRequestFromCommit;
-    const prResponse = await octokit.rest.pulls.get({
-      owner,
-      repo,
-      pull_number: sourcePr.number,
-    });
-    const pr = prResponse.data as PullRequest;
+  for (let attempt = 0; attempt <= retryDelaysMs.length; attempt++) {
+    const pr = await fetchPrForCommit(token, commitSha);
+    if (pr) return pr;
 
-    core.info(`Resolved PR #${pr.number} from latest commit ${commitSha}`);
-    return pr;
-  } catch (err) {
-    core.debug(
-      `getPrFromLatestCommit failed for commit ${commitSha}: ${String(err)}`,
+    const delayMs = retryDelaysMs[attempt];
+    if (delayMs === undefined) break;
+    core.info(
+      `No PRs associated with commit ${commitSha} yet (attempt ${attempt + 1}/${retryDelaysMs.length + 1}), retrying in ${delayMs / 1000}s…`,
     );
-    return undefined;
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
   }
+
+  core.debug(`No PRs associated with commit ${commitSha} after all retries`);
+  return undefined;
 }
 
 /**

--- a/test/github.test.ts
+++ b/test/github.test.ts
@@ -255,6 +255,7 @@ describe('github module', () => {
           listPullRequestsAssociatedWithCommit: async () => ({ data: [pr] }),
         },
         pulls: {
+          get: async () => ({ data: pr }),
           listCommits: async () => ({ data: [] }),
         },
       },
@@ -569,5 +570,63 @@ describe('github module', () => {
 
     await mod.addImpactLabelToPr('tok', 456, 'major', 'semVersie:');
     expect(addedLabel).toBe('semVersie:major');
+  });
+
+  test('getPrFromContextOrLatestCommit retries when association index is empty initially', async () => {
+    vi.useFakeTimers();
+
+    const pr = {
+      number: 99,
+      title: 'Retry PR',
+      body: '',
+      head: { ref: 'feat', sha: 'deadbeef', repo: { full_name: 'o/r' } },
+      base: { ref: 'main', sha: 'base000' },
+      labels: [],
+      draft: false,
+      merged: false,
+      merge_commit_sha: null,
+    };
+
+    let callCount = 0;
+    const ghMock = {
+      context: {
+        repo: { owner: 'o', repo: 'r' },
+        payload: {},
+        sha: 'deadbeef',
+      },
+      getOctokit: () => ({
+        rest: {
+          repos: {
+            listPullRequestsAssociatedWithCommit: async () => {
+              callCount++;
+              // Return empty on first two calls, then the PR
+              return { data: callCount < 3 ? [] : [pr] };
+            },
+          },
+          pulls: {
+            get: async () => ({ data: pr }),
+          },
+        },
+      }),
+    };
+
+    vi.doMock('@actions/github', () => ghMock);
+    vi.doMock('@actions/core', () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+    }));
+
+    const mod = await import('../src/github.js');
+
+    const resultPromise = mod.getPrFromContextOrLatestCommit('tok');
+    // Advance through the first two retry delays (5s + 10s)
+    await vi.runAllTimersAsync();
+    const result = await resultPromise;
+
+    vi.useRealTimers();
+
+    expect(result).toBeDefined();
+    expect(result!.number).toBe(99);
+    expect(callCount).toBe(3);
   });
 });

--- a/test/github.test.ts
+++ b/test/github.test.ts
@@ -4,6 +4,7 @@ describe('github module', () => {
   beforeEach(() => {
     vi.resetModules();
     process.env.GITHUB_TOKEN = 'tok';
+    delete process.env.GITHUB_SHA;
   });
 
   // Basic shared mocks for @actions/core are provided in individual tests where needed.


### PR DESCRIPTION
This pull request enhances the reliability of resolving a pull request (PR) from a commit SHA in GitHub Actions workflows, especially addressing eventual consistency issues that can occur after squash merges. It introduces a retry mechanism with exponential backoff when looking up the associated PR, and adds a corresponding test to ensure this behavior works as expected.