### PR TITLE
fix: bundle actions and core

### DIFF
--- a/.github/workflows/qualify.yaml
+++ b/.github/workflows/qualify.yaml
@@ -57,6 +57,8 @@ jobs:
         run: npm ci
       - name: build distribution
         run: npm run build
+      - name: remove node_modules
+        run: rm -rf node_modules
       - id: semVersie
         name: semVersie
         uses: ./

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,6 +37,8 @@ jobs:
         run: npm install
       - name: build distribution
         run: npm run build
+      - name: remove node_modules
+        run: rm -rf node_modules
       - id: semVersie
         name: semVersie
         uses: ./

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "publint": "0.3.21",
         "tsdown": "0.22.3",
         "typescript": "6.0.3",
+        "unrun": "^0.3.1",
         "vitest": "4.1.9"
       },
       "engines": {
@@ -2682,9 +2683,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2702,9 +2700,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2722,9 +2717,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2742,9 +2734,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2762,9 +2751,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2782,9 +2768,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5574,9 +5557,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5598,9 +5578,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5622,9 +5599,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5646,9 +5620,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7218,6 +7189,33 @@
       "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
       "license": "ISC"
     },
+    "node_modules/unrun": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/unrun/-/unrun-0.3.1.tgz",
+      "integrity": "sha512-onIck/oNnCaytwths1ZVp1LK2Gq2hPoyFhiHebObuUXqR3S0uHuLLaBK8K6mRRgV7Ptip8AnNvaUsgzwWwBZuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rolldown": "^1.0.0"
+      },
+      "bin": {
+        "unrun": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Gugustinette"
+      },
+      "peerDependencies": {
+        "synckit": "^0.11.11"
+      },
+      "peerDependenciesMeta": {
+        "synckit": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/unzip-stream": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/unzip-stream/-/unzip-stream-0.3.4.tgz",
@@ -7461,9 +7459,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7481,9 +7476,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7501,9 +7493,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7521,9 +7510,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7541,9 +7527,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7561,9 +7544,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "publint": "0.3.21",
     "tsdown": "0.22.3",
     "typescript": "6.0.3",
+    "unrun": "^0.3.1",
     "vitest": "4.1.9"
   }
 }

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -6,4 +6,5 @@ export default defineConfig({
   minify: true,
   sourcemap: true,
   publint: true,
+  deps: { alwaysBundle: ['@actions/core', '@actions/github'] },
 });


### PR DESCRIPTION
Before PR #179, the build tool was @vercel/ncc:
`"build": "ncc build src/index.ts -o dist -m"`

That should not have been a `no-impact` release.

When PR #179 switched to tsdown, the config was:

```
export default defineConfig({
  entry: 'src/index.ts',
  outDir: 'dist',
  minify: true,
  sourcemap: true,
  publint: true,
  // ← no bundling directive for dependencies
});
```

> [!NOTE]
> By removing the `node_modules/` in the workflows, we should prevent this from happening a next time.